### PR TITLE
AHB-01S: Deprecated Native Asset Transfers

### DIFF
--- a/contracts/WrapperHub/AaveHelper.sol
+++ b/contracts/WrapperHub/AaveHelper.sol
@@ -279,6 +279,25 @@ abstract contract AaveHelper is Declarations {
         );
     }
 
+    function _sendValue(
+        address _recipient,
+        uint256 _amount
+    )
+        internal
+    {
+        if (address(this).balance < _amount) {
+            revert InvalidValue();
+        }
+
+        (bool success, ) = payable(_recipient).call{
+            value: _amount
+        }("");
+
+        if (success == false) {
+            revert FailedInnerCall();
+        }
+    }
+
     function _getInfoPayback(
         uint256 _ethSent,
         uint256 _maxPaybackAmount

--- a/contracts/WrapperHub/AaveHub.sol
+++ b/contracts/WrapperHub/AaveHub.sol
@@ -85,7 +85,8 @@ contract AaveHub is AaveHelper, TransferHelper, ApprovalHelper {
             return;
         }
 
-        payable(master).transfer(
+        _sendValue(
+            master,
             msg.value
         );
     }
@@ -273,7 +274,8 @@ contract AaveHub is AaveHelper, TransferHelper, ApprovalHelper {
             _withdrawAmount
         );
 
-        payable(msg.sender).transfer(
+        _sendValue(
+            msg.sender,
             _withdrawAmount
         );
 
@@ -344,7 +346,8 @@ contract AaveHub is AaveHelper, TransferHelper, ApprovalHelper {
             withdrawAmount
         );
 
-        payable(msg.sender).transfer(
+        _sendValue(
+            msg.sender,
             withdrawAmount
         );
 
@@ -433,7 +436,8 @@ contract AaveHub is AaveHelper, TransferHelper, ApprovalHelper {
             _borrowAmount
         );
 
-        payable(msg.sender).transfer(
+        _sendValue(
+            msg.sender,
             _borrowAmount
         );
 
@@ -549,7 +553,8 @@ contract AaveHub is AaveHelper, TransferHelper, ApprovalHelper {
         );
 
         if (ethRefundAmount > 0) {
-            payable(msg.sender).transfer(
+            _sendValue(
+                msg.sender,
                 ethRefundAmount
             );
         }
@@ -797,7 +802,8 @@ contract AaveHub is AaveHelper, TransferHelper, ApprovalHelper {
             _withdrawAmount
         );
 
-        payable(msg.sender).transfer(
+        _sendValue(
+            msg.sender,
             _withdrawAmount
         );
 

--- a/contracts/WrapperHub/Declarations.sol
+++ b/contracts/WrapperHub/Declarations.sol
@@ -13,6 +13,8 @@ import "../InterfaceHub/IPositionNFTs.sol";
 import "../OwnableMaster.sol";
 
 error AlreadySet();
+error InvalidValue();
+error FailedInnerCall();
 
 contract Declarations is OwnableMaster, AaveEvents {
 


### PR DESCRIPTION
- adding _sendValue() from OZ
- utilize instead of native .transfer()
- this is proposed by auditor